### PR TITLE
Improve Streamlit front-end robustness and tests

### DIFF
--- a/tests/test_streamlit_app.py
+++ b/tests/test_streamlit_app.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import os
+from typing import Any, Dict
+from streamlit.testing.v1 import AppTest
+
+
+class DummyResponse:
+    def __init__(self, payload: Dict[str, Any], status_code: int = 200):
+        self._payload = payload
+        self.status_code = status_code
+
+    def json(self) -> Dict[str, Any]:
+        return self._payload
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+    @property
+    def ok(self) -> bool:
+        return self.status_code < 400
+
+
+def test_app_warns_when_no_input_dirs(monkeypatch, tmp_path):
+    monkeypatch.setenv("STREAMLIT_INPUT_ROOT", str(tmp_path / "inputs"))
+    apptest = AppTest.from_file("web/streamlit_app.py")
+    apptest.run()
+    warnings = [message.value for message in apptest.warning]
+    assert any("未找到任何输入目录" in message for message in warnings)
+
+
+def test_scan_and_translate_flow(monkeypatch, tmp_path):
+    input_root = tmp_path / "inputs"
+    output_root = tmp_path / "outputs"
+    (input_root / "demo").mkdir(parents=True)
+
+    monkeypatch.setenv("STREAMLIT_INPUT_ROOT", str(input_root))
+    monkeypatch.setenv("STREAMLIT_OUTPUT_ROOT", str(output_root))
+    monkeypatch.setenv("STREAMLIT_STATUS_INTERVAL", "0")
+
+    call_log: Dict[str, Any] = {"scan_params": None, "translate_payload": None, "status_calls": 0}
+
+    def fake_get(url: str, params: Dict[str, Any] | None = None):
+        if url.endswith("/scan_dir"):
+            call_log["scan_params"] = params
+            return DummyResponse({"files": ["demo/file.txt"], "total": 1})
+        if url.endswith("/status"):
+            call_log["status_calls"] += 1
+            return DummyResponse(
+                {
+                    "progress": 100,
+                    "status": "completed",
+                    "message": "翻译完成",
+                    "translated_files": [str(output_root / "demo" / "file_translated.txt")],
+                }
+            )
+        raise AssertionError(f"Unexpected GET {url}")
+
+    def fake_post(url: str, json: Dict[str, Any] | None = None):
+        if url.endswith("/translate"):
+            call_log["translate_payload"] = json
+            return DummyResponse({"status": "started"})
+        raise AssertionError(f"Unexpected POST {url}")
+
+    monkeypatch.setattr("requests.get", fake_get)
+    monkeypatch.setattr("requests.post", fake_post)
+
+    apptest = AppTest.from_file("web/streamlit_app.py")
+    apptest.run()
+
+    # 执行扫描
+    apptest.button[0].click().run()
+
+    assert call_log["scan_params"] == {"dir_path": os.path.join(str(input_root), "demo"), "file_types": ""}
+    assert any("找到 1 个文件" in message.value for message in apptest.markdown)
+
+    # 执行翻译
+    apptest.button[1].click().run()
+
+    assert call_log["translate_payload"] == {
+        "input_dir": os.path.join(str(input_root), "demo"),
+        "output_dir": str(output_root),
+        "target_lang": "zh",
+        "file_types": "",
+        "model": None,
+    }
+    assert call_log["status_calls"] >= 1
+    assert any("翻译完成！" in message.value for message in apptest.success)
+

--- a/web/streamlit_app.py
+++ b/web/streamlit_app.py
@@ -1,61 +1,111 @@
-import streamlit as st
-import requests
-import json
-import time
 import os
+import time
+from contextlib import suppress
+from typing import List
 
-st.title("翻译GUI")
+import requests
+import streamlit as st
 
-subdirs = [d for d in os.listdir('test') if os.path.isdir(os.path.join('test', d))]
-input_dir_options = [f"test/{d}" for d in subdirs]
-input_dir = st.selectbox("输入目录", options=input_dir_options)
 
-file_types = st.text_input("文件类型 (逗号分隔)", value="")
+def get_input_root() -> str:
+    return os.getenv("STREAMLIT_INPUT_ROOT", "test")
 
-if st.button("扫描文件"):
-    params = {"dir_path": input_dir, "file_types": file_types}
-    response = requests.get("http://localhost:8000/scan_dir", params=params)
-    response.raise_for_status()
-    data = response.json()
-    st.write(f"找到 {data['total']} 个文件: {data['files']}")
 
-if st.button("开始翻译"):
-    payload = {"input_dir": input_dir, "output_dir": "output", "target_lang": "zh", "file_types": file_types, "model": None}
-    response = requests.post("http://localhost:8000/translate", json=payload)
-    response.raise_for_status()
-    progress_placeholder = st.empty()
-    status_placeholder = st.empty()
-    total_files = 0
-    poll_count = 0
-    max_polls = 300
-    completed = False
-    while poll_count < max_polls:
-        status_response = requests.get("http://localhost:8000/status")
-        if status_response.ok:
-            data = status_response.json()
-            if "total_files" in data and total_files == 0:
-                total_files = data["total_files"]
-            status_placeholder.write(data.get("message", ""))
-            if total_files > 1 and data.get("progress") is not None:
-                progress_placeholder.progress(min(data["progress"] / 100, 1.0))
-            if "error" in data:
-                st.error(f"错误: {data['error']}")
-                completed = True
-                break
-            if data.get("progress") == 100 and data.get("status") == "completed":
-                st.success("翻译完成！")
-                if "translated_files" in data:
-                    st.write("翻译文件: ", data["translated_files"])
-                if data.get("errors"):
-                    st.warning("警告: ", data["errors"])
-                completed = True
-                break
-        time.sleep(1)
-        poll_count += 1
-    if not completed:
-        st.error("翻译超时或失败")
+def get_output_root() -> str:
+    return os.getenv("STREAMLIT_OUTPUT_ROOT", "output")
 
-st.sidebar.info("后端需运行: uvicorn web.app:app --reload")
+
+def get_status_poll_interval() -> float:
+    return float(os.getenv("STREAMLIT_STATUS_INTERVAL", "1.0"))
+
+
+def get_input_directories(base_dir: str | None = None) -> List[str]:
+    """Return a list of sub-directories inside the given base directory."""
+
+    base_dir = base_dir or get_input_root()
+
+    if not os.path.exists(base_dir):
+        return []
+
+    return [
+        os.path.join(base_dir, d)
+        for d in sorted(os.listdir(base_dir))
+        if os.path.isdir(os.path.join(base_dir, d))
+    ]
+
+
+def render_app() -> None:
+    st.title("翻译GUI")
+
+    input_root = get_input_root()
+    output_root = get_output_root()
+    poll_interval = get_status_poll_interval()
+
+    input_dir_options = get_input_directories(input_root)
+
+    if not input_dir_options:
+        st.warning(
+            "未找到任何输入目录，请在 test 文件夹下添加子目录或设置 STREAMLIT_INPUT_ROOT。"
+        )
+        st.stop()
+
+    input_dir = st.selectbox("输入目录", options=input_dir_options)
+
+    file_types = st.text_input("文件类型 (逗号分隔)", value="")
+
+    if st.button("扫描文件"):
+        params = {"dir_path": input_dir, "file_types": file_types}
+        response = requests.get("http://localhost:8000/scan_dir", params=params)
+        response.raise_for_status()
+        data = response.json()
+        st.write(f"找到 {data['total']} 个文件: {data['files']}")
+
+    if st.button("开始翻译"):
+        payload = {
+            "input_dir": input_dir,
+            "output_dir": output_root,
+            "target_lang": "zh",
+            "file_types": file_types,
+            "model": None,
+        }
+        response = requests.post("http://localhost:8000/translate", json=payload)
+        response.raise_for_status()
+        progress_placeholder = st.empty()
+        status_placeholder = st.empty()
+        total_files = 0
+        poll_count = 0
+        max_polls = 300
+        completed = False
+        while poll_count < max_polls:
+            status_response = requests.get("http://localhost:8000/status")
+            with suppress(requests.HTTPError):
+                status_response.raise_for_status()
+            if status_response.ok:
+                data = status_response.json()
+                if "total_files" in data and total_files == 0:
+                    total_files = data["total_files"]
+                status_placeholder.write(data.get("message", ""))
+                if total_files > 0 and data.get("progress") is not None:
+                    progress_placeholder.progress(min(data["progress"] / 100, 1.0))
+                if "error" in data:
+                    st.error(f"错误: {data['error']}")
+                    completed = True
+                    break
+                if data.get("progress") == 100 and data.get("status") == "completed":
+                    st.success("翻译完成！")
+                    if "translated_files" in data:
+                        st.write("翻译文件: ", data["translated_files"])
+                    if data.get("errors"):
+                        st.warning("警告: ", data["errors"])
+                    completed = True
+                    break
+            time.sleep(poll_interval)
+            poll_count += 1
+        if not completed:
+            st.error("翻译超时或失败")
+
+    st.sidebar.info("后端需运行: uvicorn web.app:app --reload")
+
 
 if __name__ == "__main__":
-    pass
+    render_app()


### PR DESCRIPTION
## Summary
- refactor the Streamlit UI to derive its configuration from environment variables and gracefully handle missing input directories
- harden progress polling and progress display while keeping the sidebar instructions intact
- add Streamlit AppTest-based tests covering empty directory handling and the scan/translate happy path

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ccc3c2faec83218511cf9455bb1e35