### PR TITLE
Improve Streamlit frontend robustness and tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ uvicorn
 streamlit
 python-multipart
 slowapi
+pytest

--- a/tests/test_frontend_helpers.py
+++ b/tests/test_frontend_helpers.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+import sys
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from web.frontend_helpers import list_input_directories, progress_to_fraction
+
+
+def test_list_input_directories_returns_base_when_missing(tmp_path: Path):
+    missing_dir = tmp_path / "not_there"
+    assert list_input_directories(str(missing_dir)) == [str(missing_dir)]
+
+
+def test_list_input_directories_returns_subdirectories(tmp_path: Path):
+    base = tmp_path / "test"
+    (base / "a").mkdir(parents=True)
+    (base / "b").mkdir()
+
+    options = list_input_directories(str(base))
+
+    assert options == [str(base / "a"), str(base / "b")]
+
+
+@pytest.mark.parametrize(
+    "progress, expected",
+    [
+        (None, None),
+        (0, 0.0),
+        (50, 0.5),
+        (100, 1.0),
+        (150, 1.0),
+        (-10, 0.0),
+    ],
+)
+def test_progress_to_fraction(progress, expected):
+    assert progress_to_fraction(progress) == expected
+

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -1,0 +1,2 @@
+"""Web front-end package."""
+

--- a/web/frontend_helpers.py
+++ b/web/frontend_helpers.py
@@ -1,0 +1,34 @@
+"""Utility helpers for the Streamlit front-end."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+
+def list_input_directories(base_path: str = "test") -> List[str]:
+    """Return available input directories under ``base_path``.
+
+    Streamlit renders a ``selectbox`` for users to pick an input directory. If
+    the ``test`` folder does not contain sub-directories the original
+    implementation would result in an empty options list and Streamlit raises a
+    ``StreamlitAPIException``.  The helper guarantees that at least the base
+    folder itself is returned so the UI always has something to show.
+    """
+
+    base = Path(base_path)
+    if not base.exists():
+        return [base_path]
+
+    subdirs: Iterable[Path] = (p for p in base.iterdir() if p.is_dir())
+    options = [str(base / subdir.name) for subdir in sorted(subdirs)]
+    return options or [base_path]
+
+
+def progress_to_fraction(progress: Optional[float]) -> Optional[float]:
+    """Convert a percentage value from the API to a Streamlit progress fraction."""
+
+    if progress is None:
+        return None
+    return max(0.0, min(progress / 100.0, 1.0))
+

--- a/web/streamlit_app.py
+++ b/web/streamlit_app.py
@@ -1,13 +1,15 @@
-import streamlit as st
-import requests
 import json
-import time
 import os
+import time
+
+import requests
+import streamlit as st
+
+from web.frontend_helpers import list_input_directories, progress_to_fraction
 
 st.title("翻译GUI")
 
-subdirs = [d for d in os.listdir('test') if os.path.isdir(os.path.join('test', d))]
-input_dir_options = [f"test/{d}" for d in subdirs]
+input_dir_options = list_input_directories("test")
 input_dir = st.selectbox("输入目录", options=input_dir_options)
 
 file_types = st.text_input("文件类型 (逗号分隔)", value="")
@@ -36,8 +38,10 @@ if st.button("开始翻译"):
             if "total_files" in data and total_files == 0:
                 total_files = data["total_files"]
             status_placeholder.write(data.get("message", ""))
-            if total_files > 1 and data.get("progress") is not None:
-                progress_placeholder.progress(min(data["progress"] / 100, 1.0))
+            if total_files >= 1:
+                fraction = progress_to_fraction(data.get("progress"))
+                if fraction is not None:
+                    progress_placeholder.progress(fraction)
             if "error" in data:
                 st.error(f"错误: {data['error']}")
                 completed = True


### PR DESCRIPTION
## Summary
- add reusable helpers for directory discovery and progress formatting in the Streamlit front-end package
- update the Streamlit UI to rely on the helpers, fixing the single-file progress bug and improving import ordering
- include pytest-based coverage for the helpers and add the dependency to requirements

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ccc3c2faec83218511cf9455bb1e35